### PR TITLE
improve event tracking and data management

### DIFF
--- a/mm/2s2h/Achievements/AchievementFileStorage.cpp
+++ b/mm/2s2h/Achievements/AchievementFileStorage.cpp
@@ -1,0 +1,272 @@
+// Local includes
+#include "AchievementFileStorage.h"
+#include "StaticData/Types.h"
+
+// Standard library
+#include <cstdint>
+#include <fstream>
+#include <filesystem>
+#include <iomanip>
+#include <string>
+#include <functional>
+#include <unordered_map>
+
+// Third-party
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+
+// Ship/libultraship
+#include <ship/Context.h>
+
+namespace Achievements {
+
+namespace FileStorage {
+
+using json = nlohmann::json;
+
+constexpr const char* ACHIEVEMENTS_FILE_NAME = "2S2HAchievementsData.json";
+constexpr uint32_t CURRENT_FILE_VERSION = 1;
+constexpr const char* FILE_TYPE = "2S2H_ACHIEVEMENTS";
+
+void AchievementFileStorage_Migration_1(json& j);
+
+const std::unordered_map<uint32_t, std::function<void(json&)>> migrations = {
+    { 0, AchievementFileStorage_Migration_1 },
+};
+
+int MigrateAchievementsFile(json& j) {
+    try {
+        int version = j.value("version", 0);
+
+        if (version > (int)CURRENT_FILE_VERSION) {
+            SPDLOG_ERROR("Achievements file version {} is greater than current version {}", version,
+                         CURRENT_FILE_VERSION);
+            return -1;
+        }
+
+        while (version < (int)CURRENT_FILE_VERSION) {
+            if (migrations.contains(version)) {
+                auto migration = migrations.at(version);
+                migration(j);
+            } else {
+                SPDLOG_ERROR("Missing migration function for version {} to {}", version, version + 1);
+                return -1;
+            }
+            version = j["version"] = version + 1;
+        }
+        return 0;
+    } catch (std::exception& e) {
+        SPDLOG_ERROR("Failed to migrate achievements file: {}", e.what());
+        return -1;
+    } catch (...) {
+        SPDLOG_ERROR("Failed to migrate achievements file");
+        return -1;
+    }
+}
+
+void AchievementFileStorage_Migration_1(json& j) {
+    // Migration from version 0 to 1: Establishes baseline format (no data transformation)
+}
+
+std::string GetAchievementsFilePath() {
+    return Ship::Context::GetPathRelativeToAppDirectory(ACHIEVEMENTS_FILE_NAME);
+}
+
+void InitializeAchievementsFile() {
+    std::string filePath = GetAchievementsFilePath();
+
+    if (!std::filesystem::exists(filePath)) {
+        json initFile =
+            json{ { "version", CURRENT_FILE_VERSION },      { "type", FILE_TYPE },
+                  { "unlocked", nlohmann::json::array() },  { "events", nlohmann::json::array() },
+                  { "counters", nlohmann::json::object() }, { "unlockTimestamps", nlohmann::json::object() } };
+
+        std::ofstream file(filePath);
+        if (file.is_open()) {
+            file << std::setw(4) << initFile << std::endl;
+            if (!file.good()) {
+                SPDLOG_ERROR("Failed to write achievements file: {}", filePath);
+                return;
+            }
+            file.close();
+        } else {
+            SPDLOG_ERROR("Failed to open achievements file for writing: {}", filePath);
+        }
+    }
+}
+
+void LoadAchievementsData(AchievementData& data) {
+    std::string filePath = GetAchievementsFilePath();
+    json fileData;
+
+    std::ifstream inputFile(filePath);
+    if (!inputFile.is_open()) {
+        SPDLOG_WARN("Achievements file not found, using defaults: {}", filePath);
+        data.unlocked.clear();
+        data.events.clear();
+        data.counters.clear();
+        data.unlockTimestamps.clear();
+        return;
+    }
+
+    try {
+        inputFile >> fileData;
+        inputFile.close();
+
+        // Validate file type
+        if (!fileData.contains("type") || fileData["type"] != FILE_TYPE) {
+            SPDLOG_WARN("Invalid achievements file type, using defaults");
+            data.unlocked.clear();
+            data.events.clear();
+            data.counters.clear();
+            data.unlockTimestamps.clear();
+            return;
+        }
+
+        // Validate and migrate version
+        int fileVersion = fileData.value("version", 0);
+        if (fileVersion > (int)CURRENT_FILE_VERSION) {
+            SPDLOG_ERROR("Achievements file version {} is greater than current version {}, using defaults", fileVersion,
+                         CURRENT_FILE_VERSION);
+            data.unlocked.clear();
+            data.events.clear();
+            data.counters.clear();
+            data.unlockTimestamps.clear();
+            return;
+        }
+        if (MigrateAchievementsFile(fileData) != 0) {
+            SPDLOG_WARN("Failed to migrate achievements file, using defaults");
+            data.unlocked.clear();
+            data.events.clear();
+            data.counters.clear();
+            data.unlockTimestamps.clear();
+            return;
+        }
+
+        // Save migrated file back to disk
+        if (fileVersion < (int)CURRENT_FILE_VERSION) {
+            try {
+                std::ofstream outputFile(filePath);
+                if (outputFile.is_open()) {
+                    outputFile << std::setw(4) << fileData << std::endl;
+                    if (!outputFile.good()) {
+                        SPDLOG_WARN("Failed to save migrated achievements file: {}", filePath);
+                    }
+                    outputFile.close();
+                }
+            } catch (...) { SPDLOG_WARN("Failed to save migrated achievements file: {}", filePath); }
+        }
+
+        // Load unlocked array
+        if (fileData.contains("unlocked") && fileData["unlocked"].is_array()) {
+            data.unlocked = fileData["unlocked"].get<std::vector<bool>>();
+        } else {
+            data.unlocked.clear();
+        }
+
+        // Load events array
+        if (fileData.contains("events") && fileData["events"].is_array()) {
+            data.events = fileData["events"].get<std::vector<bool>>();
+        } else {
+            data.events.clear();
+        }
+
+        // Load counters
+        if (fileData.contains("counters") && fileData["counters"].is_object()) {
+            for (auto& [key, value] : fileData["counters"].items()) {
+                if (value.is_number_unsigned()) {
+                    data.counters[key] = value.get<uint32_t>();
+                }
+            }
+        } else {
+            data.counters.clear();
+        }
+
+        // Load unlock timestamps
+        if (fileData.contains("unlockTimestamps") && fileData["unlockTimestamps"].is_object()) {
+            data.unlockTimestamps.clear();
+            for (auto& [key, value] : fileData["unlockTimestamps"].items()) {
+                try {
+                    uint32_t achievementId = static_cast<uint32_t>(std::stoul(key));
+                    if (achievementId >= static_cast<uint32_t>(AchievementId::ACHIEVEMENT_ID_MAX)) {
+                        SPDLOG_WARN("Achievement ID out of range in unlockTimestamps: {}", achievementId);
+                        continue;
+                    }
+                    if (value.is_array()) {
+                        std::vector<uint64_t> timestamps;
+                        for (auto& ts : value) {
+                            if (ts.is_number_unsigned()) {
+                                timestamps.push_back(ts.get<uint64_t>());
+                            }
+                        }
+                        data.unlockTimestamps[achievementId] = timestamps;
+                    }
+                } catch (const std::invalid_argument&) {
+                    SPDLOG_WARN("Invalid achievement ID in unlockTimestamps: {}", key);
+                    continue;
+                } catch (const std::out_of_range&) {
+                    SPDLOG_WARN("Achievement ID out of range in unlockTimestamps: {}", key);
+                    continue;
+                }
+            }
+        } else {
+            data.unlockTimestamps.clear();
+        }
+
+    } catch (const nlohmann::json::exception& e) {
+        SPDLOG_ERROR("Failed to parse achievements file: {}", e.what());
+        data.unlocked.clear();
+        data.events.clear();
+        data.counters.clear();
+        data.unlockTimestamps.clear();
+    } catch (...) {
+        SPDLOG_ERROR("Failed to load achievements file");
+        data.unlocked.clear();
+        data.events.clear();
+        data.counters.clear();
+        data.unlockTimestamps.clear();
+    }
+}
+
+void SaveAchievementsData(const AchievementData& data) {
+    std::string filePath = GetAchievementsFilePath();
+    std::filesystem::path filePathObj(filePath);
+    auto parentDir = filePathObj.parent_path();
+
+    // Create parent directory if it doesn't exist
+    if (!parentDir.empty() && !std::filesystem::exists(parentDir)) {
+        try {
+            std::filesystem::create_directories(parentDir);
+        } catch (const std::filesystem::filesystem_error& e) {
+            SPDLOG_ERROR("Failed to create parent directory for achievements file: {}", e.what());
+            return;
+        }
+    }
+
+    json fileData = json{ { "version", CURRENT_FILE_VERSION }, { "type", FILE_TYPE },
+                          { "unlocked", data.unlocked },       { "events", data.events },
+                          { "counters", data.counters },       { "unlockTimestamps", nlohmann::json::object() } };
+
+    // Convert unlockTimestamps map to JSON object
+    for (const auto& [achievementId, timestamps] : data.unlockTimestamps) {
+        fileData["unlockTimestamps"][std::to_string(achievementId)] = timestamps;
+    }
+
+    try {
+        std::ofstream outputFile(filePath);
+        if (!outputFile.is_open()) {
+            SPDLOG_ERROR("Failed to open achievements file for writing: {}", filePath);
+            return;
+        }
+        outputFile << std::setw(4) << fileData << std::endl;
+        if (!outputFile.good()) {
+            SPDLOG_ERROR("Failed to write achievements file: {}", filePath);
+            return;
+        }
+        outputFile.close();
+    } catch (...) { SPDLOG_ERROR("Failed to save achievements file: {}", filePath); }
+}
+
+} // namespace FileStorage
+
+} // namespace Achievements

--- a/mm/2s2h/Achievements/AchievementFileStorage.cpp
+++ b/mm/2s2h/Achievements/AchievementFileStorage.cpp
@@ -173,6 +173,7 @@ void LoadAchievementsData(AchievementData& data) {
 
         // Load counters
         if (fileData.contains("counters") && fileData["counters"].is_object()) {
+            data.counters.clear();
             for (auto& [key, value] : fileData["counters"].items()) {
                 if (value.is_number_unsigned()) {
                     data.counters[key] = value.get<uint32_t>();

--- a/mm/2s2h/Achievements/AchievementFileStorage.h
+++ b/mm/2s2h/Achievements/AchievementFileStorage.h
@@ -1,0 +1,38 @@
+#ifndef ACHIEVEMENT_FILE_STORAGE_H
+#define ACHIEVEMENT_FILE_STORAGE_H
+
+// Local includes
+#include "StaticData/Types.h"
+
+// Standard library
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+// Third-party
+#include <nlohmann/json.hpp>
+
+namespace Achievements {
+
+namespace FileStorage {
+
+struct AchievementData {
+    std::vector<bool> unlocked;
+    std::vector<bool> events;
+    std::map<std::string, uint32_t> counters;
+    std::map<uint32_t, std::vector<uint64_t>> unlockTimestamps;
+};
+
+void InitializeAchievementsFile();
+void LoadAchievementsData(AchievementData& data);
+void SaveAchievementsData(const AchievementData& data);
+
+// Migration system
+int MigrateAchievementsFile(nlohmann::json& j);
+
+} // namespace FileStorage
+
+} // namespace Achievements
+
+#endif // ACHIEVEMENT_FILE_STORAGE_H

--- a/mm/2s2h/Achievements/AchievementIntegration.cpp
+++ b/mm/2s2h/Achievements/AchievementIntegration.cpp
@@ -35,6 +35,9 @@ namespace Integration {
 #define ACH_TRACK_SCENE_FLAG(sceneId, flagType, flag, event) \
     { { sceneId, ACH_FT(flagType), flag }, ACH_AE(event) }
 
+#define ACH_TRACK_BOSS(actorId, event) \
+    { actorId, ACH_AE(event) }
+
 #define ACH_TRACK_VB(event, ...)                                 \
     {                                                            \
         [](va_list args) -> bool { __VA_ARGS__; }, ACH_AE(event) \
@@ -45,6 +48,7 @@ std::map<GIVanillaBehavior, std::vector<std::pair<std::function<bool(va_list)>, 
 namespace {
 std::map<std::pair<FlagType, u32>, AchievementEvent> flagToEventMap;
 std::map<std::tuple<s16, FlagType, u32>, AchievementEvent> sceneFlagToEventMap;
+std::map<s16, AchievementEvent> bossToEventMap;
 } // namespace
 
 void Init() {
@@ -209,6 +213,12 @@ void Init() {
     // clang-format on
 
     // clang-format off
+    bossToEventMap = {
+        ACH_TRACK_BOSS(ACTOR_BOSS_07, EVENT_DEFEATED_MAJORA),
+    };
+    // clang-format on
+
+    // clang-format off
     vanillaBehaviorMap = {
         { ACH_VB(VB_START_CUTSCENE), {
             ACH_TRACK_VB(EVENT_PLAYED_SONG_OF_DOUBLE_TIME, 
@@ -236,6 +246,13 @@ void OnSceneFlagSet(s16 sceneId, FlagType flagType, u32 flag) {
     }
 }
 
+void OnBossDefeated(s16 actorId) {
+    const auto it = bossToEventMap.find(actorId);
+    if (it != bossToEventMap.end()) {
+        QUEUE_ACHIEVEMENT(it->second);
+    }
+}
+
 void OnVanillaBehavior(GIVanillaBehavior flag, bool* /*should*/, va_list originalArgs) {
     const auto it = vanillaBehaviorMap.find(flag);
     if (it != vanillaBehaviorMap.end()) {
@@ -255,6 +272,7 @@ void OnVanillaBehavior(GIVanillaBehavior flag, bool* /*should*/, va_list origina
 #undef ACH_FT
 #undef ACH_TRACK_FLAG
 #undef ACH_TRACK_SCENE_FLAG
+#undef ACH_TRACK_BOSS
 #undef ACH_TRACK_VB
 
 } // namespace Integration

--- a/mm/2s2h/Achievements/AchievementIntegration.h
+++ b/mm/2s2h/Achievements/AchievementIntegration.h
@@ -21,6 +21,8 @@ void OnFlagSet(FlagType flagType, u32 flag);
 
 void OnSceneFlagSet(s16 sceneId, FlagType flagType, u32 flag);
 
+void OnBossDefeated(s16 actorId);
+
 void OnVanillaBehavior(GIVanillaBehavior flag, bool* should, va_list originalArgs);
 
 extern std::map<GIVanillaBehavior, std::vector<std::pair<std::function<bool(va_list)>, AchievementEvent>>>

--- a/mm/2s2h/Achievements/Achievements.cpp
+++ b/mm/2s2h/Achievements/Achievements.cpp
@@ -241,7 +241,6 @@ void Init() {
     if (CVarGetInteger("gEnhancements.Achievements.Enabled", 0)) {
         std::lock_guard<std::mutex> lock(achievementDataMutex);
         FileStorage::LoadAchievementsData(achievementData);
-        RegisterAchievementTracker();
     }
 }
 
@@ -252,7 +251,6 @@ void EnableAchievements() {
         std::lock_guard<std::mutex> lock(achievementDataMutex);
         FileStorage::LoadAchievementsData(achievementData);
     }
-    RegisterAchievementTracker();
 }
 
 bool IsUnlocked(AchievementId achievementId) {

--- a/mm/2s2h/Achievements/Achievements.cpp
+++ b/mm/2s2h/Achievements/Achievements.cpp
@@ -1,12 +1,14 @@
 // Local includes
 #include "Achievements.h"
 #include "AchievementIntegration.h"
+#include "AchievementFileStorage.h"
 #include "StaticData/Registry.h"
 
 // Standard library
 #include <cstring>
 #include <functional>
 #include <map>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -23,6 +25,7 @@ extern "C" {
 
 // 2s2h
 #include "2s2h/BenGui/Notification.h"
+#include "2s2h/BenPort.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 
@@ -42,6 +45,9 @@ struct AchievementQueueEvent {
 
 std::vector<AchievementQueueEvent> achievementQueue;
 bool processing = false;
+FileStorage::AchievementData achievementData;
+static std::mutex achievementDataMutex;
+static std::mutex achievementQueueMutex;
 
 inline bool IsValidAchievementId(AchievementId achievementId) {
     const int idIndex = static_cast<int>(achievementId);
@@ -53,13 +59,112 @@ inline bool IsValidEventId(AchievementEvent achievementEventId) {
     return eventIndex >= 0 && eventIndex < static_cast<int>(AchievementEvent::ACHIEVEMENT_EVENT_MAX);
 }
 
+void EnsureVectorsSized(FileStorage::AchievementData& data) {
+    if (data.unlocked.size() < static_cast<size_t>(AchievementId::ACHIEVEMENT_ID_MAX)) {
+        data.unlocked.resize(static_cast<size_t>(AchievementId::ACHIEVEMENT_ID_MAX), false);
+    }
+    if (data.events.size() < static_cast<size_t>(AchievementEvent::ACHIEVEMENT_EVENT_MAX)) {
+        data.events.resize(static_cast<size_t>(AchievementEvent::ACHIEVEMENT_EVENT_MAX), false);
+    }
+}
+
+std::string GetEventCounterKey(AchievementEvent eventId) {
+    return std::to_string(static_cast<int>(eventId));
+}
+
+uint32_t GetEventCounter(AchievementEvent eventId) {
+    std::lock_guard<std::mutex> lock(achievementDataMutex);
+    EnsureVectorsSized(achievementData);
+    std::string key = GetEventCounterKey(eventId);
+    auto it = achievementData.counters.find(key);
+    return (it != achievementData.counters.end()) ? it->second : 0;
+}
+
+uint32_t GetEventCounterUnlocked(AchievementEvent eventId, const FileStorage::AchievementData& data) {
+    // Assumes mutex is already held
+    std::string key = GetEventCounterKey(eventId);
+    auto it = data.counters.find(key);
+    return (it != data.counters.end()) ? it->second : 0;
+}
+
+void IncrementEventCounter(AchievementEvent eventId) {
+    if (!IsValidEventId(eventId)) {
+        return;
+    }
+
+    FileStorage::AchievementData dataCopy;
+    {
+        std::lock_guard<std::mutex> lock(achievementDataMutex);
+        EnsureVectorsSized(achievementData);
+        std::string key = GetEventCounterKey(eventId);
+        achievementData.counters[key]++;
+        // Also update boolean flag for backward compatibility
+        const int eventIndex = static_cast<int>(eventId);
+        achievementData.events[eventIndex] = true;
+        dataCopy = achievementData;
+    }
+    FileStorage::SaveAchievementsData(dataCopy);
+}
+
+void ResetEventCounter(AchievementEvent eventId) {
+    if (!IsValidEventId(eventId)) {
+        return;
+    }
+
+    FileStorage::AchievementData dataCopy;
+    {
+        std::lock_guard<std::mutex> lock(achievementDataMutex);
+        EnsureVectorsSized(achievementData);
+        std::string key = GetEventCounterKey(eventId);
+        achievementData.counters[key] = 0;
+        // Also update boolean flag for backward compatibility
+        const int eventIndex = static_cast<int>(eventId);
+        achievementData.events[eventIndex] = false;
+        dataCopy = achievementData;
+    }
+    FileStorage::SaveAchievementsData(dataCopy);
+}
+
+void SetEventCounterValue(AchievementEvent eventId, uint32_t count) {
+    if (!IsValidEventId(eventId)) {
+        return;
+    }
+
+    FileStorage::AchievementData dataCopy;
+    {
+        std::lock_guard<std::mutex> lock(achievementDataMutex);
+        EnsureVectorsSized(achievementData);
+        std::string key = GetEventCounterKey(eventId);
+        achievementData.counters[key] = count;
+        // Also update boolean flag for backward compatibility
+        const int eventIndex = static_cast<int>(eventId);
+        achievementData.events[eventIndex] = (count > 0);
+        dataCopy = achievementData;
+    }
+    FileStorage::SaveAchievementsData(dataCopy);
+}
+
 bool IsAchievementComplete(const Achievement* achievement) {
     if (!achievement) {
         return false;
     }
 
+    std::lock_guard<std::mutex> lock(achievementDataMutex);
+    EnsureVectorsSized(achievementData);
+
     for (const AchievementEvent requiredEvent : achievement->requiredEvents) {
-        if (!IsEventTriggered(requiredEvent)) {
+        // Get required count (defaults to 1 if not specified)
+        uint32_t requiredCount = 1;
+        auto it = achievement->eventCounts.find(requiredEvent);
+        if (it != achievement->eventCounts.end()) {
+            requiredCount = it->second;
+        }
+
+        // Get current counter value (using unlocked version since we already hold the lock)
+        uint32_t currentCount = GetEventCounterUnlocked(requiredEvent, achievementData);
+
+        // Check if we've met the required count
+        if (currentCount < requiredCount) {
             return false;
         }
     }
@@ -76,13 +181,25 @@ void UnlockAchievement(AchievementId achievementId, bool fromEditor) {
         return;
     }
 
-    const int idIndex = static_cast<int>(achievementId);
-    gSaveContext.save.shipSaveInfo.achievements.unlocked[idIndex] = true;
+    FileStorage::AchievementData dataCopy;
+    {
+        std::lock_guard<std::mutex> lock(achievementDataMutex);
+        const int idIndex = static_cast<int>(achievementId);
+
+        EnsureVectorsSized(achievementData);
+
+        achievementData.unlocked[idIndex] = true;
+        uint64_t timestamp = GetUnixTimestamp();
+        achievementData.unlockTimestamps[idIndex].push_back(timestamp);
+        dataCopy = achievementData;
+    }
+    FileStorage::SaveAchievementsData(dataCopy);
 
     if (fromEditor) {
         Notification::EmitAchievement(achievement->iconPath ? achievement->iconPath : "",
                                       std::string(achievement->name), achievement->harbourMastery);
     } else {
+        std::lock_guard<std::mutex> lock(achievementQueueMutex);
         achievementQueue.push_back({ SHOW_UNLOCK, AchievementEvent::ACHIEVEMENT_EVENT_MAX, achievementId, 0, 0,
                                      AchievementEvent::ACHIEVEMENT_EVENT_MAX });
     }
@@ -108,6 +225,7 @@ void ShowAchievementProgress(AchievementId achievementId, AchievementEvent trigg
         Notification::EmitAchievementProgressWithEvent(achievement->iconPath ? achievement->iconPath : "", eventName,
                                                        achievement->name, current, max);
     } else {
+        std::lock_guard<std::mutex> lock(achievementQueueMutex);
         achievementQueue.push_back(
             { SHOW_PROGRESS, AchievementEvent::ACHIEVEMENT_EVENT_MAX, achievementId, current, max, triggeringEventId });
     }
@@ -117,11 +235,23 @@ void ShowAchievementProgress(AchievementId achievementId, AchievementEvent trigg
 void Init() {
     StaticData::Init();
     Integration::Init();
+    FileStorage::InitializeAchievementsFile();
+
+    // Load achievement data if achievements are enabled
+    if (CVarGetInteger("gEnhancements.Achievements.Enabled", 0)) {
+        std::lock_guard<std::mutex> lock(achievementDataMutex);
+        FileStorage::LoadAchievementsData(achievementData);
+        RegisterAchievementTracker();
+    }
 }
 
 void EnableAchievements() {
-    memset(&gSaveContext.save.shipSaveInfo.achievements, 0, sizeof(AchievementSaveData));
-    gSaveContext.save.shipSaveInfo.achievements.achievementsSystemEnabled = true;
+    CVarSetInteger("gEnhancements.Achievements.Enabled", 1);
+    CVarSave();
+    {
+        std::lock_guard<std::mutex> lock(achievementDataMutex);
+        FileStorage::LoadAchievementsData(achievementData);
+    }
     RegisterAchievementTracker();
 }
 
@@ -130,8 +260,10 @@ bool IsUnlocked(AchievementId achievementId) {
         return false;
     }
 
+    std::lock_guard<std::mutex> lock(achievementDataMutex);
+    EnsureVectorsSized(achievementData);
     const int idIndex = static_cast<int>(achievementId);
-    return gSaveContext.save.shipSaveInfo.achievements.unlocked[idIndex];
+    return achievementData.unlocked[idIndex];
 }
 
 bool IsEventTriggered(AchievementEvent achievementEventId) {
@@ -139,8 +271,10 @@ bool IsEventTriggered(AchievementEvent achievementEventId) {
         return false;
     }
 
+    std::lock_guard<std::mutex> lock(achievementDataMutex);
+    EnsureVectorsSized(achievementData);
     const int eventIndex = static_cast<int>(achievementEventId);
-    return gSaveContext.save.shipSaveInfo.achievements.events[eventIndex];
+    return achievementData.events[eventIndex];
 }
 
 void GetProgress(AchievementId achievementId, uint32_t& current, uint32_t& max) {
@@ -152,16 +286,131 @@ void GetProgress(AchievementId achievementId, uint32_t& current, uint32_t& max) 
         return;
     }
 
-    max = static_cast<uint32_t>(achievement->requiredEvents.size());
+    // Calculate max as sum of all required counts
+    max = 0;
+    for (const AchievementEvent requiredEvent : achievement->requiredEvents) {
+        uint32_t requiredCount = 1;
+        auto it = achievement->eventCounts.find(requiredEvent);
+        if (it != achievement->eventCounts.end()) {
+            requiredCount = it->second;
+        }
+        max += requiredCount;
+    }
+
     if (max == 0) {
         max = 1;
     }
 
-    for (const AchievementEvent requiredEvent : achievement->requiredEvents) {
-        if (IsEventTriggered(requiredEvent)) {
-            current++;
+    // Calculate current as sum of actual progress (capped at required count per event)
+    {
+        std::lock_guard<std::mutex> lock(achievementDataMutex);
+        EnsureVectorsSized(achievementData);
+        for (const AchievementEvent requiredEvent : achievement->requiredEvents) {
+            uint32_t requiredCount = 1;
+            auto it = achievement->eventCounts.find(requiredEvent);
+            if (it != achievement->eventCounts.end()) {
+                requiredCount = it->second;
+            }
+
+            uint32_t eventCurrent = GetEventCounterUnlocked(requiredEvent, achievementData);
+            // Cap at required count to avoid over-counting
+            current += (eventCurrent < requiredCount) ? eventCurrent : requiredCount;
         }
     }
+}
+
+void EnsureDataLoaded() {
+    std::lock_guard<std::mutex> lock(achievementDataMutex);
+    // Check if data is already loaded by checking if vectors are sized
+    if (achievementData.unlocked.size() < static_cast<size_t>(AchievementId::ACHIEVEMENT_ID_MAX) ||
+        achievementData.events.size() < static_cast<size_t>(AchievementEvent::ACHIEVEMENT_EVENT_MAX)) {
+        // Data not loaded, load it now
+        FileStorage::LoadAchievementsData(achievementData);
+    }
+}
+
+bool IsUnlockedReadOnly(AchievementId achievementId) {
+    if (!IsValidAchievementId(achievementId)) {
+        return false;
+    }
+
+    EnsureDataLoaded();
+
+    std::lock_guard<std::mutex> lock(achievementDataMutex);
+    EnsureVectorsSized(achievementData);
+    const int idIndex = static_cast<int>(achievementId);
+    return achievementData.unlocked[idIndex];
+}
+
+bool IsEventTriggeredReadOnly(AchievementEvent achievementEventId) {
+    if (!IsValidEventId(achievementEventId)) {
+        return false;
+    }
+
+    EnsureDataLoaded();
+
+    std::lock_guard<std::mutex> lock(achievementDataMutex);
+    EnsureVectorsSized(achievementData);
+    const int eventIndex = static_cast<int>(achievementEventId);
+    return achievementData.events[eventIndex];
+}
+
+void GetProgressReadOnly(AchievementId achievementId, uint32_t& current, uint32_t& max) {
+    current = 0;
+    max = 1;
+
+    const Achievement* achievement = StaticData::GetAchievement(achievementId);
+    if (!achievement) {
+        return;
+    }
+
+    EnsureDataLoaded();
+
+    // Calculate max as sum of all required counts
+    max = 0;
+    for (const AchievementEvent requiredEvent : achievement->requiredEvents) {
+        uint32_t requiredCount = 1;
+        auto it = achievement->eventCounts.find(requiredEvent);
+        if (it != achievement->eventCounts.end()) {
+            requiredCount = it->second;
+        }
+        max += requiredCount;
+    }
+
+    if (max == 0) {
+        max = 1;
+    }
+
+    // Calculate current as sum of actual progress (capped at required count per event)
+    {
+        std::lock_guard<std::mutex> lock(achievementDataMutex);
+        EnsureVectorsSized(achievementData);
+        for (const AchievementEvent requiredEvent : achievement->requiredEvents) {
+            uint32_t requiredCount = 1;
+            auto it = achievement->eventCounts.find(requiredEvent);
+            if (it != achievement->eventCounts.end()) {
+                requiredCount = it->second;
+            }
+
+            uint32_t eventCurrent = GetEventCounterUnlocked(requiredEvent, achievementData);
+            // Cap at required count to avoid over-counting
+            current += (eventCurrent < requiredCount) ? eventCurrent : requiredCount;
+        }
+    }
+}
+
+uint32_t GetEventCounterReadOnly(AchievementEvent achievementEventId) {
+    if (!IsValidEventId(achievementEventId)) {
+        return 0;
+    }
+
+    EnsureDataLoaded();
+
+    std::lock_guard<std::mutex> lock(achievementDataMutex);
+    EnsureVectorsSized(achievementData);
+    std::string key = GetEventCounterKey(achievementEventId);
+    auto it = achievementData.counters.find(key);
+    return (it != achievementData.counters.end()) ? it->second : 0;
 }
 
 void QueueEvent(AchievementEvent achievementEventId) {
@@ -169,32 +418,47 @@ void QueueEvent(AchievementEvent achievementEventId) {
         return;
     }
 
-    for (const auto& queuedEvent : achievementQueue) {
-        if (queuedEvent.type == QUEUE_ACHIEVEMENT && queuedEvent.achievementEventId == achievementEventId) {
-            return;
+    {
+        std::lock_guard<std::mutex> lock(achievementQueueMutex);
+        for (const auto& queuedEvent : achievementQueue) {
+            if (queuedEvent.type == QUEUE_ACHIEVEMENT && queuedEvent.achievementEventId == achievementEventId) {
+                return;
+            }
         }
-    }
 
-    achievementQueue.push_back({ QUEUE_ACHIEVEMENT, achievementEventId, AchievementId::ACHIEVEMENT_ID_MAX, 0, 0,
-                                 AchievementEvent::ACHIEVEMENT_EVENT_MAX });
+        achievementQueue.push_back({ QUEUE_ACHIEVEMENT, achievementEventId, AchievementId::ACHIEVEMENT_ID_MAX, 0, 0,
+                                     AchievementEvent::ACHIEVEMENT_EVENT_MAX });
+    }
 }
 
 void ProcessQueuedEvents() {
-    if (processing || achievementQueue.empty() || !IS_ACHIEVEMENTS)
+    if (!IS_ACHIEVEMENTS)
         return;
 
     Player* player = GET_PLAYER(gPlayState);
-    if (!player || gPlayState->msgCtx.msgMode != 0 || Player_InBlockingCsMode(gPlayState, player) ||
-        (player->stateFlags1 & PLAYER_STATE1_DEAD))
+    if (!player)
         return;
 
-    AchievementQueueEvent& nextEvent = achievementQueue.front();
-    if ((nextEvent.type == SHOW_UNLOCK || nextEvent.type == SHOW_PROGRESS) && Notification::IsNotificationActive())
-        return;
+    AchievementQueueEvent event;
+    bool hasEvent = false;
 
-    processing = true;
-    AchievementQueueEvent event = achievementQueue.front();
-    achievementQueue.erase(achievementQueue.begin());
+    {
+        std::lock_guard<std::mutex> lock(achievementQueueMutex);
+        if (processing || achievementQueue.empty())
+            return;
+
+        AchievementQueueEvent& nextEvent = achievementQueue.front();
+        if ((nextEvent.type == SHOW_UNLOCK || nextEvent.type == SHOW_PROGRESS) && Notification::IsNotificationActive())
+            return;
+
+        processing = true;
+        event = achievementQueue.front();
+        achievementQueue.erase(achievementQueue.begin());
+        hasEvent = true;
+    }
+
+    if (!hasEvent)
+        return;
 
     switch (event.type) {
         case QUEUE_ACHIEVEMENT:
@@ -227,7 +491,10 @@ void ProcessQueuedEvents() {
             break;
     }
 
-    processing = false;
+    {
+        std::lock_guard<std::mutex> lock(achievementQueueMutex);
+        processing = false;
+    }
 }
 
 void TriggerEvent(AchievementEvent achievementEventId, bool fromEditor) {
@@ -235,11 +502,12 @@ void TriggerEvent(AchievementEvent achievementEventId, bool fromEditor) {
         return;
     }
 
-    const bool wasAlreadyTriggered = IsEventTriggered(achievementEventId);
-    if (!wasAlreadyTriggered && IsValidEventId(achievementEventId)) {
-        const int eventIndex = static_cast<int>(achievementEventId);
-        gSaveContext.save.shipSaveInfo.achievements.events[eventIndex] = true;
+    if (!IsValidEventId(achievementEventId)) {
+        return;
     }
+
+    // Always increment counter (handles both single and multi-count events)
+    IncrementEventCounter(achievementEventId);
 
     const Event* event = StaticData::GetEvent(achievementEventId);
     if (!event) {
@@ -258,7 +526,10 @@ void TriggerEvent(AchievementEvent achievementEventId, bool fromEditor) {
 
         if (IsAchievementComplete(achievement)) {
             UnlockAchievement(achievementId, fromEditor);
-        } else if (!wasAlreadyTriggered) {
+        } else {
+            // Show progress for incomplete achievements
+            // IsAchievementComplete check above prevents showing progress when it would unlock
+            // ShowAchievementProgress filters out single-event achievements (max <= 1) to avoid spam
             ShowAchievementProgress(achievementId, achievementEventId, fromEditor);
         }
     }
@@ -269,8 +540,15 @@ void Lock(AchievementId achievementId) {
         return;
     }
 
-    const int idIndex = static_cast<int>(achievementId);
-    gSaveContext.save.shipSaveInfo.achievements.unlocked[idIndex] = false;
+    FileStorage::AchievementData dataCopy;
+    {
+        std::lock_guard<std::mutex> lock(achievementDataMutex);
+        const int idIndex = static_cast<int>(achievementId);
+        EnsureVectorsSized(achievementData);
+        achievementData.unlocked[idIndex] = false;
+        dataCopy = achievementData;
+    }
+    FileStorage::SaveAchievementsData(dataCopy);
 }
 
 void ResetEvent(AchievementEvent achievementEventId) {
@@ -279,8 +557,8 @@ void ResetEvent(AchievementEvent achievementEventId) {
     }
 
     if (IsValidEventId(achievementEventId)) {
-        const int eventIndex = static_cast<int>(achievementEventId);
-        gSaveContext.save.shipSaveInfo.achievements.events[eventIndex] = false;
+        // Reset counter (also handles boolean flag reset for backward compatibility)
+        ResetEventCounter(achievementEventId);
     }
 
     const Event* event = StaticData::GetEvent(achievementEventId);
@@ -290,6 +568,52 @@ void ResetEvent(AchievementEvent achievementEventId) {
 
     for (const AchievementId achievementId : event->dependentAchievements) {
         Lock(achievementId);
+    }
+}
+
+void SetEventCounter(AchievementEvent achievementEventId, uint32_t count, bool fromEditor) {
+    if (!IS_ACHIEVEMENTS) {
+        return;
+    }
+
+    if (!IsValidEventId(achievementEventId)) {
+        return;
+    }
+
+    // Set counter (also handles boolean flag update for backward compatibility)
+    SetEventCounterValue(achievementEventId, count);
+
+    const Event* event = StaticData::GetEvent(achievementEventId);
+    if (!event) {
+        return;
+    }
+
+    if (count > 0) {
+        // Check for achievement unlocks (like TriggerEvent)
+        for (const AchievementId achievementId : event->dependentAchievements) {
+            if (IsUnlocked(achievementId)) {
+                continue;
+            }
+
+            const Achievement* achievement = StaticData::GetAchievement(achievementId);
+            if (!achievement) {
+                continue;
+            }
+
+            if (IsAchievementComplete(achievement)) {
+                UnlockAchievement(achievementId, fromEditor);
+            } else {
+                // Show progress for incomplete achievements
+                // IsAchievementComplete check above prevents showing progress when it would unlock
+                // ShowAchievementProgress filters out single-event achievements (max <= 1) to avoid spam
+                ShowAchievementProgress(achievementId, achievementEventId, fromEditor);
+            }
+        }
+    } else {
+        // Lock dependent achievements (like ResetEvent)
+        for (const AchievementId achievementId : event->dependentAchievements) {
+            Lock(achievementId);
+        }
     }
 }
 
@@ -304,23 +628,13 @@ void RegisterAchievementTracker() {
         Achievements::Integration::OnSceneFlagSet(sceneId, flagType, flag);
     });
 
+    COND_HOOK(OnBossDefeated, IS_ACHIEVEMENTS, [](s16 actorId) { Achievements::Integration::OnBossDefeated(actorId); });
+
     for (const auto& [vbFlag, conditions] : Achievements::Integration::vanillaBehaviorMap) {
         COND_VB_SHOULD(vbFlag, IS_ACHIEVEMENTS, { Achievements::Integration::OnVanillaBehavior(_, should, args); });
     }
 }
 
-void RegisterAchievementCore() {
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSaveInit>([](s16 fileNum) {
-        if (CVarGetInteger("gEnhancements.Achievements.Enabled", 0)) {
-            memset(&gSaveContext.save.shipSaveInfo.achievements, 0, sizeof(AchievementSaveData));
-            gSaveContext.save.shipSaveInfo.achievements.achievementsSystemEnabled = true;
-        }
-    });
-
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSaveLoad>(
-        [](s16 fileNum) { RegisterAchievementTracker(); });
-}
-
-static RegisterShipInitFunc initFunc(RegisterAchievementCore, {});
+static RegisterShipInitFunc initFunc(RegisterAchievementTracker, { "gEnhancements.Achievements.Enabled" });
 
 } // namespace Achievements

--- a/mm/2s2h/Achievements/Achievements.h
+++ b/mm/2s2h/Achievements/Achievements.h
@@ -8,23 +8,31 @@
 #include <cstdint>
 #include <vector>
 
+// Ship/libultraship
+#include <libultraship/bridge/consolevariablebridge.h>
+
 extern "C" {
 #include "variables.h"
-#include "z64save.h"
 }
 
 namespace Achievements {
 
 void Init();
 void RegisterAchievementTracker();
-void RegisterAchievementCore();
 
 bool IsUnlocked(AchievementId achievementId);
 bool IsEventTriggered(AchievementEvent achievementEventId);
 
 void GetProgress(AchievementId achievementId, uint32_t& current, uint32_t& max);
 
+// Read-only query functions for viewing achievements (bypass IS_ACHIEVEMENTS check)
+bool IsUnlockedReadOnly(AchievementId achievementId);
+bool IsEventTriggeredReadOnly(AchievementEvent achievementEventId);
+void GetProgressReadOnly(AchievementId achievementId, uint32_t& current, uint32_t& max);
+uint32_t GetEventCounterReadOnly(AchievementEvent achievementEventId);
+
 void TriggerEvent(AchievementEvent achievementEventId, bool fromEditor = false);
+void SetEventCounter(AchievementEvent achievementEventId, uint32_t count, bool fromEditor = false);
 void EnableAchievements();
 void Lock(AchievementId achievementId);
 void ResetEvent(AchievementEvent achievementEventId);
@@ -33,7 +41,7 @@ void ProcessQueuedEvents();
 
 } // namespace Achievements
 
-#define IS_ACHIEVEMENTS (gSaveContext.save.shipSaveInfo.achievements.achievementsSystemEnabled)
+#define IS_ACHIEVEMENTS (CVarGetInteger("gEnhancements.Achievements.Enabled", 0))
 
 #define QUEUE_ACHIEVEMENT(eventId)             \
     do {                                       \

--- a/mm/2s2h/Achievements/StaticData/Registry.cpp
+++ b/mm/2s2h/Achievements/StaticData/Registry.cpp
@@ -3,6 +3,7 @@
 
 // Standard library
 #include <map>
+#include <utility>
 #include <vector>
 
 // Assets
@@ -24,16 +25,43 @@ namespace StaticData {
 #define ACH_AI(id) AchievementId::id
 #define ACH_AC(category) AchievementCategory::category
 #define ACH_AE(event) AchievementEvent::event
+#define ACH_AE_COUNT(event, count) std::make_pair(AchievementEvent::event, static_cast<uint32_t>(count))
 #define ACH_TEX(path) (const char*)path
 
-#define ACH_ACHIEVEMENT_ENTRY(id, name, description, iconPath, secret, category, harbourMastery, ...) \
-    {                                                                                                 \
-        id, {                                                                                         \
-            id, name, description, iconPath, secret, category, harbourMastery, {                      \
-                __VA_ARGS__                                                                           \
-            }                                                                                         \
-        }                                                                                             \
+// Helper to process events (handles both AchievementEvent and std::pair<AchievementEvent, uint32_t>)
+namespace {
+template <typename T> void ProcessEvent(Achievement& a, T&& event) {
+    if constexpr (std::is_same_v<std::decay_t<T>, AchievementEvent>) {
+        a.requiredEvents.push_back(event);
+        // eventCounts will be populated in post-processing, defaulting to 1
+    } else if constexpr (std::is_same_v<std::decay_t<T>, std::pair<AchievementEvent, uint32_t>>) {
+        a.requiredEvents.push_back(event.first);
+        a.eventCounts[event.first] = event.second;
     }
+}
+
+template <typename... Args> void ProcessEvents(Achievement& a, Args&&... args) {
+    (ProcessEvent(a, std::forward<Args>(args)), ...);
+}
+
+template <AchievementId Id>
+Achievement MakeAchievement(const char* name, const char* description, const char* iconPath, bool secret,
+                            AchievementCategory category, int harbourMastery, auto... events) {
+    Achievement a;
+    a.id = Id;
+    a.name = name;
+    a.description = description;
+    a.iconPath = iconPath;
+    a.secret = secret;
+    a.category = category;
+    a.harbourMastery = harbourMastery;
+    ProcessEvents(a, events...);
+    return a;
+}
+} // namespace
+
+#define ACH_ACHIEVEMENT_ENTRY(id, name, description, iconPath, secret, category, harbourMastery, ...) \
+    { id, MakeAchievement<id>(name, description, iconPath, secret, category, harbourMastery, __VA_ARGS__) }
 
 #define ACH_EVENT_ENTRY(id, name, description) \
     {                                          \
@@ -308,6 +336,16 @@ void Init() {
             20,
             ACH_AE(EVENT_PLAYED_SONG_OF_DOUBLE_TIME),
             ACH_AE(EVENT_PLAYED_INVERTED_SONG_OF_TIME)
+        ),
+
+        ACH_ACHIEVEMENT_ENTRY(ACH_AI(MAJORA_SLAYER),
+            "Majora Slayer",
+            "Defeat Majora 10 times",
+            ACH_TEX(gItemIcons[ITEM_MASK_FIERCE_DEITY]),    // TODO: Find or create a better icon
+            false,
+            ACH_AC(GENERAL),
+            50,
+            ACH_AE_COUNT(EVENT_DEFEATED_MAJORA, 10)
         )
     };
     // clang-format on
@@ -457,8 +495,18 @@ void Init() {
         ACH_EVENT_ENTRY(ACH_AE(EVENT_RECEIVED_OCEAN_TITLE_DEED), "Received Ocean Title Deed",
                         "Player obtained the Ocean Title Deed"),
         ACH_EVENT_ENTRY(ACH_AE(EVENT_ZORA_HALL_EVAN_HP), "Zora Hall Evan Reward",
-                        "Player received a Heart Piece from Evan")
+                        "Player received a Heart Piece from Evan"),
+        ACH_EVENT_ENTRY(ACH_AE(EVENT_DEFEATED_MAJORA), "Defeated Majora", "Player defeated Majora, the final boss")
     };
+
+    // Post-process: Set default counts to 1 for events without explicit counts
+    for (auto& [achievementId, achievement] : Data) {
+        for (const AchievementEvent requiredEvent : achievement.requiredEvents) {
+            if (achievement.eventCounts.find(requiredEvent) == achievement.eventCounts.end()) {
+                achievement.eventCounts[requiredEvent] = 1;
+            }
+        }
+    }
 
     for (auto& [achievementEventId, event] : EventData) {
         for (const auto& [achievementId, achievement] : Data) {
@@ -488,6 +536,7 @@ const Event* GetEvent(AchievementEvent achievementEventId) {
 #undef ACH_AI
 #undef ACH_AC
 #undef ACH_AE
+#undef ACH_AE_COUNT
 #undef ACH_TEX
 #undef ACH_ACHIEVEMENT_ENTRY
 #undef ACH_EVENT_ENTRY

--- a/mm/2s2h/Achievements/StaticData/Registry.h
+++ b/mm/2s2h/Achievements/StaticData/Registry.h
@@ -19,6 +19,7 @@ struct Achievement {
     AchievementCategory category;
     int harbourMastery;
     std::vector<AchievementEvent> requiredEvents;
+    std::map<AchievementEvent, uint32_t> eventCounts; // Required count per event (defaults to 1)
 };
 
 struct Event {

--- a/mm/2s2h/Achievements/StaticData/Types.h
+++ b/mm/2s2h/Achievements/StaticData/Types.h
@@ -25,6 +25,7 @@ typedef enum {
     BN_LOCAL_HERO,
 
     TIMELORD,
+    MAJORA_SLAYER,
 
     ACHIEVEMENT_ID_MAX
 } AchievementId;
@@ -109,6 +110,7 @@ typedef enum {
     EVENT_RECEIVED_RED_POTION,
     EVENT_RECEIVED_OCEAN_TITLE_DEED,
     EVENT_ZORA_HALL_EVAN_HP,
+    EVENT_DEFEATED_MAJORA,
 
     ACHIEVEMENT_EVENT_MAX
 } AchievementEvent;

--- a/mm/2s2h/Achievements/UI/AchievementsWindow.cpp
+++ b/mm/2s2h/Achievements/UI/AchievementsWindow.cpp
@@ -64,11 +64,8 @@ void AchievementsWindow::UpdateElement() {
     mIsValidGameMode =
         (gSaveContext.gameMode != GAMEMODE_TITLE_SCREEN && gSaveContext.gameMode != GAMEMODE_FILE_SELECT);
 
-    if (mIsInGame) {
-        mIsRandomizerMode = IsRandomizerMode();
-    } else {
-        mIsRandomizerMode = false;
-    }
+    // Randomizer mode detection - gSaveContext is always valid
+    mIsRandomizerMode = IsRandomizerMode();
 
     if (wasInGame != mIsInGame) {
         InvalidateCache();
@@ -76,6 +73,11 @@ void AchievementsWindow::UpdateElement() {
 }
 
 void AchievementsWindow::DrawElement() {
+    if (!IS_ACHIEVEMENTS) {
+        DrawDisabledMessage();
+        return;
+    }
+
     ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
     ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
@@ -84,18 +86,21 @@ void AchievementsWindow::DrawElement() {
 
     BeginAchievementsPanel();
 
-    if (!mIsInGame || !mIsValidGameMode) {
-        DrawNotInGameMessage();
-    } else if (!IS_ACHIEVEMENTS) {
-        DrawActivationPrompt();
-    } else {
-        DrawInGameInterface();
-    }
+    DrawInGameInterface();
 
     EndAchievementsPanel();
 
     ImGui::PopStyleVar();
     ImGui::PopStyleColor(2);
+}
+
+void AchievementsWindow::DrawDisabledMessage() {
+    const char* message =
+        ICON_FA_EXCLAMATION_TRIANGLE " Achievements are disabled. Enable them in the Enhancements menu.";
+    ImVec2 textSize = ImGui::CalcTextSize(message);
+    ImGui::SetCursorPos(
+        ImVec2((ImGui::GetWindowWidth() - textSize.x) / 2, (ImGui::GetWindowHeight() - textSize.y) / 2));
+    ImGui::TextColored(UIWidgets::ColorValues.at(UIWidgets::Colors::Orange), "%s", message);
 }
 
 void AchievementsWindow::DrawInGameInterface() {
@@ -108,39 +113,6 @@ void AchievementsWindow::DrawInGameInterface() {
     }
     ImGui::EndChild();
     ImGui::PopStyleVar();
-}
-
-void AchievementsWindow::DrawNotInGameMessage() {
-    const char* message = "Achievements can only be viewed in-game";
-    float windowWidth = ImGui::GetContentRegionAvail().x;
-    float textWidth = ImGui::CalcTextSize(message).x;
-    ImGui::SetCursorPosX((windowWidth - textWidth) * 0.5f);
-    ImGui::TextColored(UIWidgets::ColorValues.at(UIWidgets::Colors::LightGray), "%s", message);
-}
-
-void AchievementsWindow::DrawActivationPrompt() {
-    const ImVec4 primaryText = UIWidgets::ColorValues.at(UIWidgets::Colors::White);
-    const ImVec4 secondaryText = UIWidgets::ColorValues.at(UIWidgets::Colors::LightGray);
-
-    ImGui::TextColored(primaryText, "Achievements are currently OFF for this save file.");
-    ImGui::Dummy(ImVec2(0, AchievementsUI::Layout::TIGHT_SPACING));
-    ImGui::TextColored(secondaryText, "To start tracking progress, activate achievements for this save.");
-    ImGui::TextColored(secondaryText, "This will reset any prior (hidden) progress.");
-
-    ImGui::Dummy(ImVec2(0, AchievementsUI::Layout::STANDARD_SPACING));
-
-    if (UIWidgets::Button("Activate Achievements for this Save File",
-                          UIWidgets::ButtonOptions()
-                              .Color(UIWidgets::Colors::Green)
-                              .Size(ImVec2(-AchievementsUI::Layout::STANDARD_SPACING * 2,
-                                           ImGui::GetFrameHeight() + AchievementsUI::Layout::TIGHT_SPACING)))) {
-        Achievements::EnableAchievements();
-        InvalidateCache();
-        ImGui::OpenPopup("AchievementEnableDisclaimer");
-        SPDLOG_INFO("Achievements enabled for current save");
-    }
-
-    DrawActivationDisclaimer();
 }
 
 void AchievementsWindow::DrawHeaderPanel() {
@@ -344,7 +316,7 @@ void AchievementsWindow::DrawAchievementCard(const Achievement* achievement) {
 
 void AchievementsWindow::DrawCardIcon(const Achievement* achievement, AchievementsUI::CardTheme theme,
                                       bool hasProgress) {
-    bool isUnlocked = IS_ACH_UNLOCKED(achievement->id);
+    bool isUnlocked = Achievements::IsUnlockedReadOnly(achievement->id);
     bool isSecret = achievement->secret;
 
     auto gui = Ship::Context::GetInstance()->GetWindow()->GetGui();
@@ -377,7 +349,7 @@ void AchievementsWindow::DrawCardIcon(const Achievement* achievement, Achievemen
 }
 
 void AchievementsWindow::DrawCardContent(const Achievement* achievement, AchievementsUI::CardTheme theme) {
-    bool isUnlocked = IS_ACH_UNLOCKED(achievement->id);
+    bool isUnlocked = Achievements::IsUnlockedReadOnly(achievement->id);
     bool isSecret = achievement->secret;
 
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(ImGui::GetStyle().ItemSpacing.x, 2.0f));
@@ -386,6 +358,13 @@ void AchievementsWindow::DrawCardContent(const Achievement* achievement, Achieve
     ImGui::PushFont(ImGui::GetIO().Fonts->Fonts[1]);
     ImGui::SetWindowFontScale(1.1f);
     ImGui::TextColored(GetTextColor(theme, true), "%s", displayName.c_str());
+
+    // Draw category pill tag if VANILLA or RANDO
+    if (achievement->category == AchievementCategory::VANILLA || achievement->category == AchievementCategory::RANDO) {
+        ImGui::SameLine(0, AchievementsUI::Card::PILL_SPACING);
+        DrawCategoryPill(achievement->category, theme);
+    }
+
     ImGui::SetWindowFontScale(1.0f);
     ImGui::PopFont();
 
@@ -435,7 +414,7 @@ void AchievementsWindow::DrawProgressIcons(const Achievement* achievement) {
 
     std::vector<std::pair<AchievementEvent, bool>> sortedEvents;
     for (const AchievementEvent achievementEventId : achievement->requiredEvents) {
-        const bool isEventTriggered = IS_ACH_TRIGGERED(achievementEventId);
+        const bool isEventTriggered = Achievements::IsEventTriggeredReadOnly(achievementEventId);
         sortedEvents.emplace_back(achievementEventId, isEventTriggered);
     }
 
@@ -545,48 +524,6 @@ void AchievementsWindow::DrawFilterButtons() {
     }
 }
 
-void AchievementsWindow::DrawActivationDisclaimer() {
-    ImVec2 popupSize(480, 0);
-    ImGui::SetNextWindowSizeConstraints(ImVec2(popupSize.x, 0), ImVec2(popupSize.x, FLT_MAX));
-
-    if (ImGui::BeginPopupModal("AchievementEnableDisclaimer", NULL,
-                               ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove |
-                                   ImGuiWindowFlags_NoSavedSettings)) {
-
-        const char* titleText = "Achievements Successfully Enabled!";
-        float titleWidth = ImGui::CalcTextSize(titleText).x;
-        float windowWidth = ImGui::GetWindowWidth();
-        ImGui::SetCursorPosX((windowWidth - titleWidth) * 0.5f);
-        ImGui::TextUnformatted(titleText);
-
-        ImGui::Separator();
-        ImGui::Spacing();
-
-        ImGui::TextWrapped(
-            "Progress tracking and unlocks will now consider actions from this point forward for this save file.");
-        ImGui::TextWrapped("Previously completed objectives on this save will not retroactively grant achievements.");
-        ImGui::Spacing();
-
-        ImGui::PushStyleColor(ImGuiCol_Text, UIWidgets::ColorValues.at(UIWidgets::Colors::Orange));
-        ImGui::TextWrapped("IMPORTANT: This change is active for your current play session. To make it permanent for "
-                           "this save file, you MUST save your game (e.g., using an Owl Statue or the Song of Time).");
-        ImGui::PopStyleColor();
-
-        ImGui::Spacing();
-        ImGui::Spacing();
-
-        float buttonWidth = 120.0f;
-        ImGui::SetCursorPosX((windowWidth - buttonWidth) * 0.5f);
-
-        if (UIWidgets::Button("OK", UIWidgets::ButtonOptions().Size(
-                                        ImVec2(buttonWidth, ImGui::GetTextLineHeightWithSpacing() * 1.5f)))) {
-            ImGui::CloseCurrentPopup();
-        }
-
-        ImGui::EndPopup();
-    }
-}
-
 AchievementsWindow::ProgressStats AchievementsWindow::CalculateProgressStats() const {
     if (!mStatsNeedUpdate) {
         return mCachedStats;
@@ -603,15 +540,10 @@ AchievementsWindow::ProgressStats AchievementsWindow::CalculateProgressStats() c
             continue;
         }
 
-        if ((achievement->category == AchievementCategory::RANDO && !mIsRandomizerMode) ||
-            (achievement->category == AchievementCategory::VANILLA && mIsRandomizerMode)) {
-            continue;
-        }
-
         stats.totalCount++;
         stats.totalScore += achievement->harbourMastery;
 
-        if (IS_ACH_UNLOCKED(id)) {
+        if (Achievements::IsUnlockedReadOnly(id)) {
             stats.unlockedCount++;
             stats.unlockedScore += achievement->harbourMastery;
         }
@@ -626,7 +558,7 @@ AchievementsWindow::ProgressStats AchievementsWindow::CalculateProgressStats() c
 AchievementsUI::CardTheme AchievementsWindow::DetermineCardTheme(const Achievement* achievement,
                                                                  bool& hasProgress) const {
     hasProgress = false;
-    bool isUnlocked = IS_ACH_UNLOCKED(achievement->id);
+    bool isUnlocked = Achievements::IsUnlockedReadOnly(achievement->id);
     bool isSecret = achievement->secret;
 
     if (isUnlocked) {
@@ -635,7 +567,7 @@ AchievementsUI::CardTheme AchievementsWindow::DetermineCardTheme(const Achieveme
 
     if (!isSecret && achievement->requiredEvents.size() > 1) {
         for (const AchievementEvent achievementEventId : achievement->requiredEvents) {
-            if (IS_ACH_TRIGGERED(achievementEventId)) {
+            if (Achievements::IsEventTriggeredReadOnly(achievementEventId)) {
                 hasProgress = true;
                 break;
             }
@@ -681,14 +613,9 @@ bool AchievementsWindow::ShouldShowAchievement(const Achievement* achievement) c
     if (!achievement)
         return false;
 
-    bool isUnlocked = IS_ACH_UNLOCKED(achievement->id);
+    bool isUnlocked = Achievements::IsUnlockedReadOnly(achievement->id);
 
     if ((mShowLockedOnly && isUnlocked) || (mShowUnlockedOnly && !isUnlocked)) {
-        return false;
-    }
-
-    if ((achievement->category == AchievementCategory::RANDO && !mIsRandomizerMode) ||
-        (achievement->category == AchievementCategory::VANILLA && mIsRandomizerMode)) {
         return false;
     }
 
@@ -895,6 +822,71 @@ void AchievementsWindow::DrawCardBackground(const ImVec2& pos, const ImVec2& siz
         drawList->AddRectFilled(pos, ImVec2(pos.x + size.x, pos.y + size.y), ImGui::ColorConvertFloat4ToU32(hoverColor),
                                 AchievementsUI::Card::BORDER_ROUNDING);
     }
+}
+
+void AchievementsWindow::DrawCategoryPill(AchievementCategory category, AchievementsUI::CardTheme theme) {
+    const char* label = (category == AchievementCategory::VANILLA) ? "Vanilla" : "Rando";
+
+    ImDrawList* drawList = ImGui::GetWindowDrawList();
+    ImVec2 cursorPos = ImGui::GetCursorScreenPos();
+
+    // Get title line height (title uses Fonts[1] with scale 1.1f, which is still active)
+    float titleLineHeight = ImGui::GetTextLineHeight();
+
+    ImGui::PushFont(ImGui::GetIO().Fonts->Fonts[1]);
+    ImGui::SetWindowFontScale(0.95f);
+    ImVec2 textSize = ImGui::CalcTextSize(label);
+    ImGui::SetWindowFontScale(1.0f);
+    ImGui::PopFont();
+
+    float height = AchievementsUI::Card::PILL_HEIGHT;
+    float padding = AchievementsUI::Card::PILL_PADDING;
+    float rounding = height * 0.5f; // Fully rounded pill
+    ImVec2 pillSize = ImVec2(textSize.x + (padding * 2.0f), height);
+
+    // Calculate vertical offset to center pill with title
+    float offsetY = (titleLineHeight - height) * 0.5f;
+    ImVec2 pillPos = ImVec2(cursorPos.x, cursorPos.y + offsetY);
+    // Add small offset to center text vertically (ImGui AddText positions at baseline)
+    ImVec2 textPos = ImVec2(pillPos.x + padding, pillPos.y + (height - textSize.y) * 0.5f + 1.5f);
+
+    // Choose colors based on category
+    ImVec4 bgColor, textColor;
+    if (category == AchievementCategory::VANILLA) {
+        bgColor = ImVec4(0.08f, 0.03f, 0.65f, 0.2f); // Blue background
+        textColor = UIWidgets::ColorValues.at(UIWidgets::Colors::White);
+    } else {                                       // RANDO
+        bgColor = ImVec4(0.55f, 0.0f, 0.0f, 0.2f); // Red background
+        textColor = UIWidgets::ColorValues.at(UIWidgets::Colors::White);
+    }
+
+    // Adjust colors based on theme for better visibility
+    if (theme == AchievementsUI::CardTheme::LOCKED) {
+        bgColor.w *= 0.5f; // More transparent for locked cards
+        textColor.w *= 0.7f;
+    }
+
+    // Draw pill background
+    drawList->AddRectFilled(pillPos, ImVec2(pillPos.x + pillSize.x, pillPos.y + pillSize.y),
+                            ImGui::ColorConvertFloat4ToU32(bgColor), rounding);
+
+    // Draw pill border (white)
+    ImVec4 borderColor = UIWidgets::ColorValues.at(UIWidgets::Colors::White);
+    if (theme == AchievementsUI::CardTheme::LOCKED) {
+        borderColor.w *= 0.7f; // More transparent for locked cards
+    }
+    drawList->AddRect(pillPos, ImVec2(pillPos.x + pillSize.x, pillPos.y + pillSize.y),
+                      ImGui::ColorConvertFloat4ToU32(borderColor), rounding, 0, 1.0f);
+
+    // Draw text
+    ImGui::PushFont(ImGui::GetIO().Fonts->Fonts[1]); // Use bold font for better readability
+    ImGui::SetWindowFontScale(0.95f);
+    drawList->AddText(textPos, ImGui::ColorConvertFloat4ToU32(textColor), label);
+    ImGui::SetWindowFontScale(1.0f);
+    ImGui::PopFont();
+
+    // Advance cursor (use original cursor position to maintain line spacing)
+    ImGui::Dummy(ImVec2(pillSize.x, titleLineHeight));
 }
 
 void AchievementsWindow::LoadSettings() {

--- a/mm/2s2h/Achievements/UI/AchievementsWindow.h
+++ b/mm/2s2h/Achievements/UI/AchievementsWindow.h
@@ -11,6 +11,9 @@
 // Ship/libultraship
 #include <ship/window/gui/GuiWindow.h>
 
+// Local includes
+#include "../StaticData/Registry.h"
+
 struct Achievement;
 
 namespace Achievements {
@@ -31,6 +34,9 @@ constexpr float HEIGHT = 80.0f;
 constexpr float PADDING = 12.0f;
 constexpr float ICON_SIZE = 60.0f;
 constexpr float BORDER_ROUNDING = 6.0f;
+constexpr float PILL_HEIGHT = 18.0f;
+constexpr float PILL_PADDING = 6.0f;
+constexpr float PILL_SPACING = 6.0f;
 } // namespace Card
 
 namespace Icon {
@@ -76,9 +82,8 @@ class AchievementsWindow : public Ship::GuiWindow {
         bool initialized = false;
     };
 
+    void DrawDisabledMessage();
     void DrawInGameInterface();
-    void DrawNotInGameMessage();
-    void DrawActivationPrompt();
     void DrawHeaderPanel();
     void DrawProgressSection();
     void DrawFilterSection();
@@ -93,11 +98,11 @@ class AchievementsWindow : public Ship::GuiWindow {
     void EndAchievementsPanel();
     void DrawFontIcon(const char* icon, const ImVec4& color, AchievementsUI::CardTheme theme);
     void DrawFilterButtons();
-    void DrawActivationDisclaimer();
     void DrawProgressIcon();
     void DrawScoreIcon();
     void DrawProgressBar(float progress, float width, float height, const ImVec4& color);
     void DrawCardBackground(const ImVec2& pos, const ImVec2& size, AchievementsUI::CardTheme theme, bool hovered);
+    void DrawCategoryPill(AchievementCategory category, AchievementsUI::CardTheme theme);
     ProgressStats CalculateProgressStats() const;
     AchievementsUI::CardTheme DetermineCardTheme(const Achievement* achievement, bool& hasProgress) const;
     bool ShouldShowAchievement(const Achievement* achievement) const;

--- a/mm/2s2h/BenGui/Notification.cpp
+++ b/mm/2s2h/BenGui/Notification.cpp
@@ -147,7 +147,16 @@ void Window::DrawEnhancedNotification(const Options& notification, ImVec2 basePo
 
     ImGui::PushStyleVar(ImGuiStyleVar_Alpha, alpha);
     ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.08f, 0.08f, 0.12f, 0.95f)); // Darker, more opaque
-    ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(1.0f, 0.85f, 0.0f, 1.0f));      // Gold border
+
+    // Use blue border for progress notifications, gold for achievement unlocks
+    ImVec4 borderColor = ImVec4(1.0f, 0.85f, 0.0f, 1.0f); // Default gold for unlocks
+    const ImVec4 goldColor = ImVec4(1.0f, 0.85f, 0.0f, 1.0f);
+    if (notification.prefixColor.x != goldColor.x || notification.prefixColor.y != goldColor.y ||
+        notification.prefixColor.z != goldColor.z) {
+        // Not gold = progress notification, use blue to match text
+        borderColor = ImVec4(0.4f, 0.8f, 1.0f, 1.0f); // Light blue matching prefix color
+    }
+    ImGui::PushStyleColor(ImGuiCol_Border, borderColor);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 2.0f);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 10.0f);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(16.0f, 12.0f));
@@ -376,7 +385,7 @@ void EmitAchievementProgressWithEvent(const char* iconPath, const char* eventNam
     Options notification;
     notification.id = nextId++;
     notification.itemIcon = iconPath;
-    notification.prefix = "Event Completed";
+    notification.prefix = "Progress Update";
     notification.prefixColor = ImVec4(0.4f, 0.8f, 1.0f, 1.0f); // Light blue
     notification.message = progressText;
     notification.messageColor = ImVec4(0.9f, 0.9f, 0.9f, 1.0f); // Light gray

--- a/mm/2s2h/BenJsonConversions.hpp
+++ b/mm/2s2h/BenJsonConversions.hpp
@@ -12,20 +12,6 @@ extern "C" {
 
 using json = nlohmann::json;
 
-void to_json(json& j, const AchievementSaveData& achievementSaveData) {
-    j = json{
-        { "achievementsSystemEnabled", achievementSaveData.achievementsSystemEnabled },
-        { "unlocked", achievementSaveData.unlocked },
-        { "events", achievementSaveData.events },
-    };
-}
-
-void from_json(const json& j, AchievementSaveData& achievementSaveData) {
-    j.at("achievementsSystemEnabled").get_to(achievementSaveData.achievementsSystemEnabled);
-    j.at("unlocked").get_to(achievementSaveData.unlocked);
-    j.at("events").get_to(achievementSaveData.events);
-}
-
 void to_json(json& j, const DpadSaveInfo& dpadEquips) {
     j = json{
         { "dpadItems", dpadEquips.dpadItems },
@@ -104,8 +90,6 @@ void to_json(json& j, const ShipSaveInfo& shipSaveInfo) {
         { "commitHash", commitHash },
     };
 
-    j["achievements"] = shipSaveInfo.achievements;
-
     if (shipSaveInfo.saveType == SAVETYPE_RANDO) {
         j["rando"] = shipSaveInfo.rando;
     }
@@ -119,13 +103,6 @@ void from_json(const json& j, ShipSaveInfo& shipSaveInfo) {
     j.at("fileCompletedAt").get_to(shipSaveInfo.fileCompletedAt);
     j.at("filePlaytime").get_to(shipSaveInfo.filePlaytime);
     j.at("commitHash").get_to(shipSaveInfo.commitHash);
-
-    if (j.contains("achievements") && j.at("achievements").is_object()) {
-        j.at("achievements").get_to(shipSaveInfo.achievements);
-    } else {
-        SPDLOG_WARN("Achievements data missing or invalid in save file. Initializing defaults.");
-        shipSaveInfo.achievements = {};
-    }
 
     if (shipSaveInfo.saveType == SAVETYPE_RANDO) {
         if (strcmp(shipSaveInfo.commitHash, gGitCommitHash) != 0) {

--- a/mm/2s2h/DeveloperTools/AchievementEditor.cpp
+++ b/mm/2s2h/DeveloperTools/AchievementEditor.cpp
@@ -98,34 +98,12 @@ void AchievementEditor::DrawElement() {
 }
 
 void AchievementEditor::DrawSystemStatus() {
-    ImGui::SeparatorText("Achievement System Status");
-
-    ImGui::TextColored(UIWidgets::ColorValues.at(UIWidgets::Colors::Orange),
-                       ICON_FA_EXCLAMATION_TRIANGLE " Achievement System Inactive");
-    ImGui::Spacing();
-
-    ImGui::TextWrapped("The achievement system is not active for this save file. "
-                       "Achievements must be enabled when creating a save to use this editor.");
-
-    ImGui::Spacing();
-    ImGui::Separator();
-    ImGui::Spacing();
-
-    ImGui::Text("To enable achievements:");
-    ImGui::BulletText("Create a new save file");
-    ImGui::BulletText("Check the 'Enable Achievements' option");
-    ImGui::BulletText("Or use the main Achievements window to enable for existing saves");
-
-    ImGui::Spacing();
-
-    if (UIWidgets::Button(
-            "Open Achievements Window",
-            UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline).Color(UIWidgets::Colors::LightBlue))) {
-        auto achievementsWindow = Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Achievements");
-        if (achievementsWindow) {
-            achievementsWindow->Show();
-        }
-    }
+    const char* message =
+        ICON_FA_EXCLAMATION_TRIANGLE " Achievements are disabled. Enable them in the Enhancements menu.";
+    ImVec2 textSize = ImGui::CalcTextSize(message);
+    ImGui::SetCursorPos(
+        ImVec2((ImGui::GetWindowWidth() - textSize.x) / 2, (ImGui::GetWindowHeight() - textSize.y) / 2));
+    ImGui::TextColored(UIWidgets::ColorValues.at(UIWidgets::Colors::Orange), "%s", message);
 }
 
 void AchievementEditor::DrawAchievementBrowser() {
@@ -444,40 +422,46 @@ void AchievementEditor::DrawEventProgressDisplay() {
     ImGui::Text("Required Events (%zu):", achievement->requiredEvents.size());
     ImGui::Spacing();
 
-    uint32_t completedEvents = 0;
-    for (const AchievementEvent achievementEventId : achievement->requiredEvents) {
-        if (IS_ACH_TRIGGERED(achievementEventId)) {
-            completedEvents++;
-        }
-    }
+    // Use GetProgress for accurate progress calculation
+    uint32_t currentProgress = 0;
+    uint32_t maxProgress = 0;
+    Achievements::GetProgress(mSelectedAchievementId, currentProgress, maxProgress);
 
-    float progress = achievement->requiredEvents.size() > 0
-                         ? static_cast<float>(completedEvents) / achievement->requiredEvents.size()
-                         : 0.0f;
+    float progress = maxProgress > 0 ? static_cast<float>(currentProgress) / maxProgress : 0.0f;
 
-    ImGui::ProgressBar(
-        progress, ImVec2(-1, 0),
-        (std::to_string(completedEvents) + "/" + std::to_string(achievement->requiredEvents.size())).c_str());
+    ImGui::ProgressBar(progress, ImVec2(-1, 0),
+                       (std::to_string(currentProgress) + "/" + std::to_string(maxProgress)).c_str());
 
     ImGui::Spacing();
 
     if (ImGui::BeginChild("EventList", ImVec2(0, 150), true)) {
-        if (ImGui::BeginTable("EventTable", 3, ImGuiTableFlags_SizingFixedFit)) {
+        if (ImGui::BeginTable("EventTable", 4, ImGuiTableFlags_SizingFixedFit)) {
             ImGui::TableSetupColumn("Status", ImGuiTableColumnFlags_WidthFixed, 30.0f);
             ImGui::TableSetupColumn("Event", ImGuiTableColumnFlags_WidthStretch);
-            ImGui::TableSetupColumn("Action", ImGuiTableColumnFlags_WidthFixed, 90.0f);
+            ImGui::TableSetupColumn("Progress", ImGuiTableColumnFlags_WidthFixed, 100.0f);
+            ImGui::TableSetupColumn("Action", ImGuiTableColumnFlags_WidthFixed, 140.0f);
 
             for (size_t i = 0; i < achievement->requiredEvents.size(); i++) {
                 const AchievementEvent achievementEventId = achievement->requiredEvents[i];
-                const bool isTriggered = IS_ACH_TRIGGERED(achievementEventId);
+
+                // Get required count (defaults to 1 if not specified)
+                uint32_t requiredCount = 1;
+                auto it = achievement->eventCounts.find(achievementEventId);
+                if (it != achievement->eventCounts.end()) {
+                    requiredCount = it->second;
+                }
+
+                // Get current count using read-only function
+                uint32_t currentCount = Achievements::GetEventCounterReadOnly(achievementEventId);
+                bool isComplete = (currentCount >= requiredCount);
 
                 ImGui::PushID(static_cast<int>(i));
                 ImGui::TableNextRow();
 
                 ImGui::TableNextColumn();
-                ImGui::TextColored(isTriggered ? UIWidgets::ColorValues.at(UIWidgets::Colors::Green)
-                                               : UIWidgets::ColorValues.at(UIWidgets::Colors::Red),
-                                   "%s", isTriggered ? ICON_FA_CHECK_CIRCLE : ICON_FA_CIRCLE);
+                ImGui::TextColored(isComplete ? UIWidgets::ColorValues.at(UIWidgets::Colors::Green)
+                                              : UIWidgets::ColorValues.at(UIWidgets::Colors::Red),
+                                   "%s", isComplete ? ICON_FA_CHECK_CIRCLE : ICON_FA_CIRCLE);
 
                 ImGui::TableNextColumn();
                 const Event* event = Achievements::StaticData::GetEvent(achievementEventId);
@@ -485,23 +469,80 @@ void AchievementEditor::DrawEventProgressDisplay() {
                 ImGui::TextWrapped("%s", eventName);
 
                 ImGui::TableNextColumn();
-                if (UIWidgets::Button(isTriggered ? "Reset" : "Trigger",
-                                      UIWidgets::ButtonOptions()
-                                          .Size(UIWidgets::Sizes::Inline)
-                                          .Color(isTriggered ? UIWidgets::Colors::Orange : UIWidgets::Colors::Green))) {
-                    if (isTriggered) {
-                        Achievements::ResetEvent(achievementEventId);
-                    } else {
-                        Achievements::TriggerEvent(achievementEventId, true);
-                    }
-                    if (BenGui::mAchievementsWindow) {
-                        BenGui::mAchievementsWindow->InvalidateCache();
-                    }
-                }
-                if (isTriggered) {
-                    UIWidgets::Tooltip("Reset this event and lock all dependent achievements");
+                if (requiredCount > 1) {
+                    ImGui::Text("%u / %u", currentCount, requiredCount);
                 } else {
-                    UIWidgets::Tooltip("Trigger this event and check for achievement unlocks");
+                    ImGui::TextColored(isComplete ? UIWidgets::ColorValues.at(UIWidgets::Colors::Green)
+                                                  : UIWidgets::ColorValues.at(UIWidgets::Colors::Gray),
+                                       "%s", isComplete ? "Complete" : "Incomplete");
+                }
+
+                ImGui::TableNextColumn();
+                if (requiredCount > 1) {
+                    // Input box with decrement/increment buttons for multi-count events
+                    ImGui::BeginGroup();
+
+                    // Decrement button (left)
+                    if (UIWidgets::Button(
+                            "-",
+                            UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline).Color(UIWidgets::Colors::Gray)) &&
+                        currentCount > 0) {
+                        Achievements::SetEventCounter(achievementEventId, currentCount - 1, true);
+                        if (BenGui::mAchievementsWindow) {
+                            BenGui::mAchievementsWindow->InvalidateCache();
+                        }
+                    }
+                    UIWidgets::Tooltip("Decrement counter by 1");
+                    ImGui::SameLine(0, 3.0f);
+
+                    // Input box (middle)
+                    ImGui::PushItemWidth(60.0f);
+                    UIWidgets::PushStyleInput();
+                    uint32_t inputCount = currentCount;
+                    if (ImGui::InputScalar("##counterInput", ImGuiDataType_U32, &inputCount, nullptr, nullptr, "%u",
+                                           ImGuiInputTextFlags_CharsDecimal)) {
+                        // Clamp to reasonable bounds (0 minimum, no hard maximum for flexibility)
+                        Achievements::SetEventCounter(achievementEventId, inputCount, true);
+                        if (BenGui::mAchievementsWindow) {
+                            BenGui::mAchievementsWindow->InvalidateCache();
+                        }
+                    }
+                    UIWidgets::PopStyleInput();
+                    ImGui::PopItemWidth();
+                    ImGui::SameLine(0, 3.0f);
+
+                    // Increment button (right)
+                    if (UIWidgets::Button(
+                            "+",
+                            UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline).Color(UIWidgets::Colors::Gray))) {
+                        Achievements::SetEventCounter(achievementEventId, currentCount + 1, true);
+                        if (BenGui::mAchievementsWindow) {
+                            BenGui::mAchievementsWindow->InvalidateCache();
+                        }
+                    }
+                    UIWidgets::Tooltip("Increment counter by 1");
+                    ImGui::EndGroup();
+                } else {
+                    // Single-count events: just trigger/reset
+                    if (UIWidgets::Button(
+                            isComplete ? "Reset" : "Trigger",
+                            UIWidgets::ButtonOptions()
+                                .Size(UIWidgets::Sizes::Inline)
+                                .Color(isComplete ? UIWidgets::Colors::Orange : UIWidgets::Colors::Green))) {
+                        if (isComplete) {
+                            Achievements::ResetEvent(achievementEventId);
+                        } else {
+                            Achievements::TriggerEvent(achievementEventId, true);
+                        }
+                        if (BenGui::mAchievementsWindow) {
+                            BenGui::mAchievementsWindow->InvalidateCache();
+                        }
+                    }
+                    if (isComplete) {
+                        UIWidgets::Tooltip("Reset this event counter and lock all dependent achievements");
+                    } else {
+                        UIWidgets::Tooltip("Increment this event counter and check for achievement unlocks");
+                    }
                 }
 
                 ImGui::PopID();
@@ -540,13 +581,19 @@ void AchievementEditor::DrawAchievementActions() {
                 "Unlock Achievement",
                 UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Fill).Color(UIWidgets::Colors::Green))) {
             for (const AchievementEvent achievementEventId : achievement->requiredEvents) {
-                Achievements::TriggerEvent(achievementEventId, true);
+                // Get required count (defaults to 1 if not specified)
+                uint32_t requiredCount = 1;
+                auto it = achievement->eventCounts.find(achievementEventId);
+                if (it != achievement->eventCounts.end()) {
+                    requiredCount = it->second;
+                }
+                Achievements::SetEventCounter(achievementEventId, requiredCount, true);
             }
             if (BenGui::mAchievementsWindow) {
                 BenGui::mAchievementsWindow->InvalidateCache();
             }
         }
-        UIWidgets::Tooltip("Trigger all required events to unlock this achievement");
+        UIWidgets::Tooltip("Set all required events to their required counts to unlock this achievement");
     }
 }
 
@@ -572,17 +619,19 @@ void AchievementEditor::DrawEventStatusGrid() {
     ImGui::Spacing();
 
     if (ImGui::BeginChild("EventGrid", ImVec2(0, 0), true)) {
-        if (ImGui::BeginTable("AllEventsTable", 3,
+        if (ImGui::BeginTable("AllEventsTable", 4,
                               ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_SizingFixedFit)) {
             ImGui::TableSetupColumn("ID", ImGuiTableColumnFlags_WidthFixed, 30.0f);
             ImGui::TableSetupColumn("Event Name", ImGuiTableColumnFlags_WidthStretch);
+            ImGui::TableSetupColumn("Counter", ImGuiTableColumnFlags_WidthFixed, 80.0f);
             ImGui::TableSetupColumn("Status", ImGuiTableColumnFlags_WidthFixed, 100.0f);
             ImGui::TableHeadersRow();
 
             int eventCount = static_cast<int>(AchievementEvent::ACHIEVEMENT_EVENT_MAX);
             for (int i = 0; i < eventCount; i++) {
                 AchievementEvent eventId = static_cast<AchievementEvent>(i);
-                bool isTriggered = IS_ACH_TRIGGERED(eventId);
+                uint32_t counter = Achievements::GetEventCounterReadOnly(eventId);
+                bool isTriggered = (counter > 0);
                 bool isSelected = (mSelectedEventId == eventId);
 
                 ImGui::PushID(i);
@@ -604,6 +653,10 @@ void AchievementEditor::DrawEventStatusGrid() {
                 if (ImGui::Selectable(eventName, isSelected, ImGuiSelectableFlags_SpanAllColumns)) {
                     mSelectedEventId = eventId;
                 }
+
+                // Counter
+                ImGui::TableNextColumn();
+                ImGui::Text("%u", counter);
 
                 // Status
                 ImGui::TableNextColumn();
@@ -631,18 +684,20 @@ void AchievementEditor::DrawEventTriggerControls() {
     ImGui::TextWrapped("%s", eventName);
     ImGui::Unindent();
 
-    bool isSelected = IS_ACH_TRIGGERED(mSelectedEventId);
-    ImGui::Text("Status: %s", isSelected ? "Triggered" : "Not Triggered");
+    uint32_t counter = Achievements::GetEventCounterReadOnly(mSelectedEventId);
+    bool isTriggered = (counter > 0);
+    ImGui::Text("Counter: %u", counter);
+    ImGui::Text("Status: %s", isTriggered ? "Triggered" : "Not Triggered");
 
     ImGui::Spacing();
     ImGui::Separator();
     ImGui::Spacing();
 
-    if (UIWidgets::Button(isSelected ? "Reset Event" : "Trigger Event",
+    if (UIWidgets::Button(isTriggered ? "Reset Event" : "Trigger Event",
                           UIWidgets::ButtonOptions()
                               .Size(UIWidgets::Sizes::Fill)
-                              .Color(isSelected ? UIWidgets::Colors::Orange : UIWidgets::Colors::Green))) {
-        if (isSelected) {
+                              .Color(isTriggered ? UIWidgets::Colors::Orange : UIWidgets::Colors::Green))) {
+        if (isTriggered) {
             Achievements::ResetEvent(mSelectedEventId);
         } else {
             Achievements::TriggerEvent(mSelectedEventId, true);
@@ -651,10 +706,10 @@ void AchievementEditor::DrawEventTriggerControls() {
             BenGui::mAchievementsWindow->InvalidateCache();
         }
     }
-    if (isSelected) {
-        UIWidgets::Tooltip("Reset this event and lock all achievements that depend on it");
+    if (isTriggered) {
+        UIWidgets::Tooltip("Reset this event counter and lock all achievements that depend on it");
     } else {
-        UIWidgets::Tooltip("Trigger this event and check for achievement completions");
+        UIWidgets::Tooltip("Increment this event counter and check for achievement completions");
     }
 
     ImGui::Spacing();
@@ -720,7 +775,7 @@ void AchievementEditor::DrawSystemInfo() {
     ImGui::Separator();
     ImGui::Spacing();
 
-    ImGui::Text("Save File Information:");
+    ImGui::Text("File Storage Information:");
     if (IS_ACHIEVEMENTS) {
         ImGui::BulletText("Achievements Enabled: Yes");
         ImGui::BulletText("Unlocked Achievements: %u", GetUnlockedCount());
@@ -1012,17 +1067,25 @@ void AchievementEditor::RefreshValidation() {
         }
 
         if (!IS_ACH_UNLOCKED(achId) && !achievement->requiredEvents.empty()) {
-            bool allEventsTriggered = true;
+            bool allEventsComplete = true;
             for (AchievementEvent eventId : achievement->requiredEvents) {
-                if (!IS_ACH_TRIGGERED(eventId)) {
-                    allEventsTriggered = false;
+                // Get required count (defaults to 1 if not specified)
+                uint32_t requiredCount = 1;
+                auto it = achievement->eventCounts.find(eventId);
+                if (it != achievement->eventCounts.end()) {
+                    requiredCount = it->second;
+                }
+
+                uint32_t currentCount = Achievements::GetEventCounterReadOnly(eventId);
+                if (currentCount < requiredCount) {
+                    allEventsComplete = false;
                     break;
                 }
             }
 
-            if (allEventsTriggered) {
+            if (allEventsComplete) {
                 mValidationWarnings.push_back("Achievement \"" + std::string(achievement->name) +
-                                              "\" has all events triggered but is still locked");
+                                              "\" has all events complete but is still locked");
             }
         }
     }
@@ -1128,16 +1191,25 @@ void AchievementEditor::FixCompletionIssues() {
             continue;
         }
 
-        bool allEventsTriggered = true;
+        // Check if all event counts are met
+        bool allEventsComplete = true;
         for (const AchievementEvent achievementEventId : achievement->requiredEvents) {
-            if (!IS_ACH_TRIGGERED(achievementEventId)) {
-                allEventsTriggered = false;
+            // Get required count (defaults to 1 if not specified)
+            uint32_t requiredCount = 1;
+            auto it = achievement->eventCounts.find(achievementEventId);
+            if (it != achievement->eventCounts.end()) {
+                requiredCount = it->second;
+            }
+
+            uint32_t currentCount = Achievements::GetEventCounterReadOnly(achievementEventId);
+            if (currentCount < requiredCount) {
+                allEventsComplete = false;
                 break;
             }
         }
 
-        // If all events are triggered, re-trigger one to force completion check
-        if (allEventsTriggered && !achievement->requiredEvents.empty()) {
+        // If all events are complete, trigger one to force completion check
+        if (allEventsComplete && !achievement->requiredEvents.empty()) {
             SPDLOG_DEBUG("Fixing completion issue for achievement: {}", achievement->name);
             Achievements::TriggerEvent(achievement->requiredEvents[0], true);
             fixedCount++;

--- a/mm/include/z64save.h
+++ b/mm/include/z64save.h
@@ -380,12 +380,6 @@ typedef struct RandoSaveCheck {
     u16 price; // Only applicable for shops/merchants
 } RandoSaveCheck;
 
-typedef struct AchievementSaveData {
-    bool achievementsSystemEnabled;
-    bool unlocked[ACHIEVEMENT_ID_MAX];
-    bool events[ACHIEVEMENT_EVENT_MAX];
-} AchievementSaveData;
-
 typedef struct RandoSaveInfo {
     u16 randoInf[(RANDO_INF_MAX + 15) / 16];
     u8 randoEvents[RE_MAX]; // This is purely for logic tracking, not to be used for anything else
@@ -408,7 +402,6 @@ typedef struct ShipSaveInfo {
     uint64_t filePlaytime;
     char commitHash[8];
     RandoSaveInfo rando;
-    AchievementSaveData achievements;
 } ShipSaveInfo;
 // #endregion
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves achievements to a JSON file with versioned migration, adds per-event counters and timestamps, introduces Majora defeat tracking/achievement, and updates UI/editor and hooks accordingly.
> 
> - **Storage & Data Model**
>   - Add file-based achievements persistence `2S2HAchievementsData.json` with versioned migrations, validation, and safe read/write.
>   - Track `unlocked`, `events`, per-event `counters`, and `unlockTimestamps` (ID→timestamps).
>   - Remove achievements data from `Save`/`ShipSaveInfo` and related JSON conversions.
> - **Core Logic**
>   - Replace boolean-only events with counter-based tracking (increment/reset/set); progress sums required counts per event.
>   - Add thread-safety (mutexes) for data and queue; persist after mutations.
>   - New read-only query APIs that bypass `IS_ACHIEVEMENTS`; enable via CVar.
> - **Integration & Events**
>   - Add boss defeat mapping and hook `OnBossDefeated`; map `ACTOR_BOSS_07` → `EVENT_DEFEATED_MAJORA`.
>   - Maintain existing flag/scene/vb tracking; queue handling refined.
> - **Static Data**
>   - Support per-event required counts in `Achievement` (`eventCounts`).
>   - Add achievement `MAJORA_SLAYER` requiring `EVENT_DEFEATED_MAJORA` ×10; add new event type.
> - **UI/UX**
>   - Achievements window uses read-only access; shows disabled message when off; adds category pill tags; progress icons/logic reflect counters.
>   - Notifications: progress vs unlock border color differentiation; “Progress Update” wording.
> - **Developer Tools**
>   - Editor supports viewing/editing event counters, per-event progress, and bulk ops using counters; updated diagnostics/fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ffb6317dec75af00382bec1873d0de61c23129d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-windows.zip](https://nightly.link/mckinlee/2ship2harkinian/actions/artifacts/4890091121.zip)
  - [2ship-linux.zip](https://nightly.link/mckinlee/2ship2harkinian/actions/artifacts/4890149791.zip)
  - [2ship-mac.zip](https://nightly.link/mckinlee/2ship2harkinian/actions/artifacts/4890756174.zip)
<!--- section:artifacts:end -->